### PR TITLE
Integrate optimin and supports multiple jsss files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ Confirm.
 ```
 $ jsss -h
 Usage:
-    jsss style.js           Compile JSSS to stdout
-    jsss style.js style.css Compile JSSS to file
-    jsss -h, --help         display this help message
-    jsss -v, --version      display the version number
+    jsss style.js                Compile JSSS to stdout
+    jsss style.js -o style.css   Compile JSSS to file
+
+Options:
+    -h, --help      Print this message
+    -o, --out       Output to single file
+    -e, --encoding  JSSS File encoding (default: utf8)
+    -v, --version   Print jsss-compiler version
 ```
 
 ## Example
@@ -52,7 +56,7 @@ contextual(tags.UL, tags.LI).fontSize = '10px';
 
 ### Compile
 ```
-$ jsss style.js style.css
+$ jsss style.js -o style.css
 ```
 
 ### style.css

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,66 +1,64 @@
 var fs = require('fs');
 var updateNotifier = require('update-notifier');
 var jsss = require('./jsss');
-var argv = process.argv;
 var pkg = require(__dirname + '/../package.json');
+var argv = require('optimin')(process.argv.slice(2), {
+  version: {
+    alias: 'v',
+    boolean: true
+  },
+  help: {
+    alias: 'h',
+    boolean: true
+  },
+  encoding: {
+    alias: 'e'
+  },
+  out: {
+    alias: 'o'
+  }
+});
 
 updateNotifier({
   packageName: pkg.name,
   packageVersion: pkg.version
 }).notify();
 
-if(argv[2] !== void 0) {
-  switch (argv[2]) {
-    case '-v':
-      if (argv.length === 3) {
-        jsss.version();
-      }
-      break;
-    case '--version':
-      if (argv.length === 3) {
-        jsss.version();
-      }
-      break;
-    case '-h':
-      if (argv.length === 3) {
-        jsss.help();
-      }
-      break;
-    case '--help':
-      if (argv.length === 3) {
-        jsss.help();
-      }
-      break;
-    default:
-      if (argv.length === 4 || argv.length === 3) {
-        var file = argv[2];
-        if (!fs.existsSync(file)) {
-          process.stdout.write('No such file or directory "' + file + '"\n');
-          return;
-        }
+if (argv.version) {
+  jsss.version();
+  return;
+}
 
-        var opt = {
-          encoding: 'utf8'
-        };
-        var code = fs.readFileSync(file, opt);
-        var css = jsss.parse(code);
-        var out = argv[3] || false;
+if (argv.help) {
+  jsss.help();
+  return;
+}
 
-        if (!out) {
-          process.stdout.write(css);
-        } else {
-          fs.writeFileSync(out, css);
-        }
-      } else {
-        var message = 'Unrecognized command line argument: ';
-        message += argv[2];
-        message += ' ( see: \'jsss -h\' )';
-        process.stdout.write(message);
-        break;
-      }
-  }
-} else {
+if (typeof argv._ !== 'object') {
   jsss.message();
   return;
 }
 
+var files = argv._;
+var encoding = argv.encoding || 'utf8';
+var opt = {
+  encoding: encoding
+};
+var code = '';
+var out = argv.out || false;
+
+files.forEach(function (file) {
+  if (!fs.existsSync(file)) {
+    process.stdout.write('No such file or directory "' + file + '"\n');
+    process.exit(1);
+    return;
+  }
+  code += fs.readFileSync(file, opt);
+});
+
+var css = jsss.parse(code);
+if (!out) {
+  process.stdout.write(css);
+} else {
+  fs.writeFileSync(out, css);
+}

--- a/lib/modules/help.js
+++ b/lib/modules/help.js
@@ -2,13 +2,20 @@ module.exports = function () {
   var message = '';
   message += 'Usage:';
   message += '\n';
-  message += '    jsss style.js           Compile JSSS to stdout';
+  message += '    jsss style.js                Compile JSSS to stdout';
   message += '\n';
-  message += '    jsss style.js style.css Compile JSSS to file';
+  message += '    jsss style.js -o style.css   Compile JSSS to file';
   message += '\n';
-  message += '    jsss -h, --help         display this help message';
   message += '\n';
-  message += '    jsss -v, --version      display the version number';
+  message += 'Options:'
+  message += '\n';
+  message += '    -h, --help      Print this message';
+  message += '\n';
+  message += '    -o, --out       Output to single file';
+  message += '\n';
+  message += '    -e, --encoding  JSSS File encoding (default: utf8)'
+  message += '\n';
+  message += '    -v, --version   Print jsss-compiler version';
   message += '\n';
   process.stdout.write(message);
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "css": "^2.1.0",
     "harmony-reflect": "1.0.1",
     "jsss-contextual": "^1.0.0",
+    "optimin": "^0.5.2",
     "underscore": "1.7.0",
     "update-notifier": "^0.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsss-compiler",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A altCSS: JavaScript-Based Style Sheets Preprocessor",
   "main": "lib/jsss.js",
   "bin": {


### PR DESCRIPTION
Update cli and fixes https://github.com/watilde/jsss-compiler/issues/39
```
$ jsss -h
Usage:
    jsss style.js                Compile JSSS to stdout
    jsss style.js -o style.css   Compile JSSS to file

Options:
    -h, --help      Print this message
    -o, --out       Output to single file
    -e, --encoding  JSSS File encoding (default: utf8)
    -v, --version   Print jsss-compiler version
```