### PR TITLE
lib: export modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ script:
 language: node_js
 
 node_js:
-  - iojs
-  - "0.12"
+  - 7

--- a/bin/jsss.js
+++ b/bin/jsss.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node --harmony_proxies
+#!/usr/bin/env node
 require(__dirname + '/../lib/cli')

--- a/lib/jsss.js
+++ b/lib/jsss.js
@@ -2,3 +2,8 @@ module.exports.parse = require('./modules/parse');
 module.exports.version = require('./modules/version');
 module.exports.help = require('./modules/help');
 module.exports.message = require('./modules/message');
+
+module.exports.taggen = require('./modules/taggen');
+module.exports.idgen = require('./modules/idgen');
+module.exports.classgen = require('./modules/classgen');
+module.exports.parseProxy = require('./modules/parseProxy');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jsss": "bin/jsss.js"
   },
   "scripts": {
-    "test": "node --harmony_proxies ./test/test.js"
+    "test": "node ./test/test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/watilde/jsss-compiler",
   "dependencies": {
     "css": "^2.2.1",
-    "harmony-reflect": "1.4.0",
+    "harmony-reflect": "1.5.1",
     "jsss-contextual": "^1.0.4",
     "optimin": "^0.5.2",
     "underscore": "1.8.3",


### PR DESCRIPTION
Codegen modules will be available with this patch
```js
module.exports.taggen = require('./modules/taggen');
module.exports.idgen = require('./modules/idgen');
module.exports.classgen = require('./modules/classgen');
module.exports.parseProxy = require('./modules/parseProxy');
```